### PR TITLE
Add optional provider HttpClient to VerifierConfig

### DIFF
--- a/ComPact.UnitTests/Models/V3/HttpRequestMessageFromRequestTests.cs
+++ b/ComPact.UnitTests/Models/V3/HttpRequestMessageFromRequestTests.cs
@@ -11,8 +11,6 @@ namespace ComPact.UnitTests.Models.V3
         [TestMethod]
         public void ShouldCreateHttpRequestMessageFromRequest()
         {
-            var baseUrl = "http://base";
-
             var request = new Request
             {
                 Method = Method.POST,
@@ -25,10 +23,10 @@ namespace ComPact.UnitTests.Models.V3
                 }
             };
 
-            var httpRequestMessage = request.ToHttpRequestMessage(baseUrl);
+            var httpRequestMessage = request.ToHttpRequestMessage();
 
             Assert.AreEqual(request.Method.ToString(), httpRequestMessage.Method.ToString());
-            Assert.AreEqual(baseUrl + request.Path + "?" + request.Query.ToQueryString(), httpRequestMessage.RequestUri.ToString());
+            Assert.AreEqual(request.Path + "?" + request.Query.ToQueryString(), httpRequestMessage.RequestUri.ToString());
             Assert.AreEqual("application/json", httpRequestMessage.Headers.First().Value.First());
             Assert.AreEqual("{\"text\":\"Hello World!\"}", httpRequestMessage.Content.ReadAsStringAsync().Result);
         }
@@ -36,18 +34,16 @@ namespace ComPact.UnitTests.Models.V3
         [TestMethod]
         public void ShouldCreateHttpRequestMessageFromMinimalRequest()
         {
-            var baseUrl = "http://base";
-
             var request = new Request
             {
                 Method = Method.GET,
                 Path = "/test",
             };
 
-            var httpRequestMessage = request.ToHttpRequestMessage(baseUrl);
+            var httpRequestMessage = request.ToHttpRequestMessage();
 
             Assert.AreEqual(request.Method.ToString(), httpRequestMessage.Method.ToString());
-            Assert.AreEqual(baseUrl + request.Path, httpRequestMessage.RequestUri.ToString());
+            Assert.AreEqual(request.Path, httpRequestMessage.RequestUri.ToString());
             Assert.IsFalse(httpRequestMessage.Headers.Any());
             Assert.IsNull(httpRequestMessage.Content);
         }

--- a/ComPact.UnitTests/Verifier/VerifyInteractionsTests.cs
+++ b/ComPact.UnitTests/Verifier/VerifyInteractionsTests.cs
@@ -51,7 +51,7 @@ namespace ComPact.UnitTests.Verifier
         [TestMethod]
         public async Task ShouldReturnSuccessfulTest()
         {
-            var tests = await PactVerifier.VerifyInteractions(_interactions, "http://base", (req) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)), (p) => { });
+            var tests = await PactVerifier.VerifyInteractions(_interactions, (req) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)), (p) => { });
 
             Assert.AreEqual(2, tests.Count);
             Assert.AreEqual("passed", tests.First().Status);
@@ -61,7 +61,7 @@ namespace ComPact.UnitTests.Verifier
         [TestMethod]
         public async Task ShouldReturnFailedTestWhenResponsesDoNotMatch()
         {
-            var tests = await PactVerifier.VerifyInteractions(_interactions, "http://base", (req) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)), (p) => { });
+            var tests = await PactVerifier.VerifyInteractions(_interactions, (req) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)), (p) => { });
 
             Assert.AreEqual(2, tests.Count);
             Assert.AreEqual("failed", tests.First().Status);
@@ -71,7 +71,7 @@ namespace ComPact.UnitTests.Verifier
         [TestMethod]
         public async Task ShouldReturnFailedTestWhenHandlerThrowsPactVerificationException()
         {
-            var tests = await PactVerifier.VerifyInteractions(_interactions, "http://base", (req) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)), 
+            var tests = await PactVerifier.VerifyInteractions(_interactions, (req) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)), 
                 (p) => throw new PactVerificationException("Unknown provider state."));
 
             Assert.AreEqual(2, tests.Count);

--- a/ComPact/Models/V3/Request.cs
+++ b/ComPact/Models/V3/Request.cs
@@ -57,15 +57,12 @@ namespace ComPact.Models.V3
             }
         }
 
-        public HttpRequestMessage ToHttpRequestMessage(string baseUrl)
+        public HttpRequestMessage ToHttpRequestMessage()
         {
             var method = new HttpMethod(Method.ToString());
-            var uri = baseUrl + Path;
-            if (Query.Any())
-            {
-                uri += ("?" + Query.ToQueryString());
-            }
+            var uri = Query.Any() ? $"{Path}?{Query.ToQueryString()}" : Path;
             var request = new HttpRequestMessage(method, uri);
+
             foreach (var header in Headers)
             {
                 request.Headers.Add(header.Key, header.Value);

--- a/ComPact/Verifier/PactVerifier.cs
+++ b/ComPact/Verifier/PactVerifier.cs
@@ -58,28 +58,8 @@ namespace ComPact.Verifier
                     throw new PactException("Could not verify pacts. Please configure a ProviderBaseUrl or a pre-configured ProviderHttpClient.");
                 }
 
-                var existingClient = _config.ProviderHttpClient != null;
-
-                try
-                {
-                    if (!existingClient)
-                    {
-                        _config.ProviderHttpClient = new HttpClient();
-                    }
-
-                    tests.AddRange(await VerifyInteractions(pact.Interactions, _config.ProviderBaseUrl, _config.ProviderHttpClient.SendAsync, _config.ProviderStateHandler));
-                }
-                finally
-                {
-                    if (!existingClient)
-                    {
-                        if (_config.ProviderHttpClient != null)
-                        {
-                            _config.ProviderHttpClient.Dispose();
-                            _config.ProviderHttpClient = null;
-                        }
-                    }
-                }
+                var client = _config.ProviderHttpClient ?? new HttpClient();
+                tests.AddRange(await VerifyInteractions(pact.Interactions, _config.ProviderBaseUrl, client.SendAsync, _config.ProviderStateHandler));
             }
 
             if (pact.Messages != null)

--- a/ComPact/Verifier/PactVerifierConfig.cs
+++ b/ComPact/Verifier/PactVerifierConfig.cs
@@ -1,6 +1,5 @@
 ﻿using ComPact.Models;
 using System;
-using System.Collections.Generic;
 using System.Net.Http;
 
 namespace ComPact.Verifier
@@ -11,6 +10,12 @@ namespace ComPact.Verifier
         /// The base url where to call your actual provider service. To set up provider states, {base-url}/provider-states will be called.
         /// </summary>
         public string ProviderBaseUrl { get; set; }
+
+        /// <summary>
+        /// Optional HttpClient for the provider in case you want to supply your own preconfigured instance.
+        /// </summary>
+        public HttpClient ProviderHttpClient { get; set; }
+
         /// <summary>
         /// An action that will be invoked for every provider state in a (message) interaction. Use this to set up any necessary test data.
         /// If you cannot handle a specific provider state, throw a PactVerificationException to make the issue show up in the test results


### PR DESCRIPTION
Do you accept PRs into this repo?

I wanted to use your nuget package on a project I'm working on, but wanted to use it with the AspNet TestServer. Because the VerifierConfig only allows me to pass in a base URL rather than my own pre-configured HttpClient that wasn't possible.

This PR is a relatively trivial change to allow optionally passing in a pre-configured HttpClient to allow it to be used with AspNet TestServer