### PR TITLE
Extra output

### DIFF
--- a/ComPact/Models/Body.cs
+++ b/ComPact/Models/Body.cs
@@ -3,7 +3,6 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace ComPact.Models
 {

--- a/ComPact/Models/Body.cs
+++ b/ComPact/Models/Body.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace ComPact.Models
 {
@@ -37,7 +38,18 @@ namespace ComPact.Models
             }
             catch (Exception e)
             {
-                differences.Add($"Exception thrown comparing body.\r\nExpected body:\r\n{expectedBody}\r\n\r\nActual Body:\r\n{actualBody}\r\n\r\nException:\r\n{e}");
+                var builder = new StringBuilder();
+                builder.AppendLine("Exception thrown comparing body.");
+                builder.AppendLine("Expected body:");
+                builder.AppendLine(expectedBody);
+                builder.AppendLine();
+                builder.AppendLine("Actual body:");
+                builder.AppendLine(actualBody);
+                builder.AppendLine();
+                builder.AppendLine("Exception:");
+                builder.AppendLine(e.ToString());
+
+                differences.Add(builder.ToString());
             }
 
             return differences;

--- a/ComPact/Models/Body.cs
+++ b/ComPact/Models/Body.cs
@@ -23,15 +23,22 @@ namespace ComPact.Models
                 return differences;
             }
 
-            JToken expectedRootToken = JToken.FromObject(expectedBody);
-            JToken actualRootToken = JToken.FromObject(actualBody);
-
-            foreach (var token in expectedRootToken.ThisTokenAndAllItsDescendants())
+            try
             {
-                differences.AddRange(ProcessToken(token, matchingRules, actualRootToken));
-            }
+                JToken expectedRootToken = JToken.FromObject(expectedBody);
+                JToken actualRootToken = JToken.FromObject(actualBody);
 
-            differences.AddRange(VerifyAdditionalActualTokensAgainstMatchingRules(expectedRootToken, actualRootToken, matchingRules));
+                foreach (var token in expectedRootToken.ThisTokenAndAllItsDescendants())
+                {
+                    differences.AddRange(ProcessToken(token, matchingRules, actualRootToken));
+                }
+
+                differences.AddRange(VerifyAdditionalActualTokensAgainstMatchingRules(expectedRootToken, actualRootToken, matchingRules));
+            }
+            catch (Exception e)
+            {
+                differences.Add($"Exception thrown comparing body.\r\nExpected body:\r\n{expectedBody}\r\n\r\nActual Body:\r\n{actualBody}\r\n\r\nException:\r\n{e}");
+            }
 
             return differences;
         }

--- a/ComPact/Models/Body.cs
+++ b/ComPact/Models/Body.cs
@@ -41,10 +41,10 @@ namespace ComPact.Models
                 var builder = new StringBuilder();
                 builder.AppendLine("Exception thrown comparing body.");
                 builder.AppendLine("Expected body:");
-                builder.AppendLine(expectedBody);
+                builder.AppendLine(expectedBody.ToString());
                 builder.AppendLine();
                 builder.AppendLine("Actual body:");
-                builder.AppendLine(actualBody);
+                builder.AppendLine(actualBody.ToString());
                 builder.AppendLine();
                 builder.AppendLine("Exception:");
                 builder.AppendLine(e.ToString());


### PR DESCRIPTION
Hi Bart

New PR for you :)

github is formatting the changes pretty nastily, but I've just added a try/catch around the body comparison.

I just had an issue where my API was returning an error result and it was quite hard to diagnose because the exception logged by com-pact was around failing to case from JObject to JToken deep inside Newtonsoft.Json.

Adding the below quickly exposed the fact that the API was returning an error result with some details around the error rather than the expected body.

Longer term, I might create a PR to add detailed logging about what is going on at each step, with that logging being optionally output via configuration? Normally I'd imagine you'd have it turned off, but if a test starts failing you might turn it on to help diagnose the root cause of the failure?