### PR TITLE
Handle content type header

### DIFF
--- a/ComPact.UnitTests/Models/V3/HttpRequestMessageFromRequestTests.cs
+++ b/ComPact.UnitTests/Models/V3/HttpRequestMessageFromRequestTests.cs
@@ -1,7 +1,10 @@
-﻿using ComPact.Models;
+﻿using System.Collections.Generic;
+using ComPact.Models;
 using ComPact.Models.V3;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
 
 namespace ComPact.UnitTests.Models.V3
 {
@@ -46,6 +49,47 @@ namespace ComPact.UnitTests.Models.V3
             Assert.AreEqual(request.Path, httpRequestMessage.RequestUri.ToString());
             Assert.IsFalse(httpRequestMessage.Headers.Any());
             Assert.IsNull(httpRequestMessage.Content);
+        }
+
+        [TestMethod]
+        public void ContentTypeHeaderShouldNotBeAppliedToHttpRequest()
+        {
+            var request = new Request
+            {
+                Method = Method.POST,
+                Path = "/test",
+                Headers = new Headers( new HeaderDictionary(new Dictionary<string, StringValues>
+                {
+                    {"Content-Type", new StringValues("content-type-value") }
+                }))
+            };
+
+            var httpRequestMessage = request.ToHttpRequestMessage();
+
+            Assert.IsTrue(!httpRequestMessage.Headers.Any());
+        }
+
+        [TestMethod]
+        public void ContentTypeHeaderShouldBeAppliedToContent()
+        {
+            var contentTypeMediaType = "text/html";
+
+            var request = new Request
+            {
+                Method = Method.POST,
+                Path = "/test",
+                Body = "some test body",
+                Headers = new Headers( new HeaderDictionary(new Dictionary<string, StringValues>
+                {
+                    {"Content-Type", new StringValues(contentTypeMediaType) }
+                }))
+            };
+
+            var httpRequestMessage = request.ToHttpRequestMessage();
+
+            Assert.AreEqual(httpRequestMessage.Content.Headers.Count(), 1);
+            Assert.IsTrue(httpRequestMessage.Content.Headers.Contains("Content-Type"));
+            Assert.AreEqual(httpRequestMessage.Content.Headers.ContentType.MediaType, contentTypeMediaType);
         }
     }
 }

--- a/ComPact/Models/V3/Request.cs
+++ b/ComPact/Models/V3/Request.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -14,7 +13,7 @@ namespace ComPact.Models.V3
 {
     internal class Request
     {
-        private const string contentTypeHeader = "Content-Type";
+        private const string ContentTypeHeader = "Content-Type";
 
         [JsonProperty("method")]
         [JsonConverter(typeof(StringEnumConverter))]
@@ -81,13 +80,13 @@ namespace ComPact.Models.V3
 
         private IEnumerable<KeyValuePair<string, string>> GetHeadersExceptContentType()
         {
-            return Headers.Where(h => !string.Equals(h.Key, contentTypeHeader, StringComparison.OrdinalIgnoreCase));
+            return Headers.Where(h => !string.Equals(h.Key, ContentTypeHeader, StringComparison.OrdinalIgnoreCase));
         }
 
         private string GetContentTypeHeader(string defaultValue)
         {
             var header=  Headers.SingleOrDefault(h =>
-                       string.Equals(h.Key, contentTypeHeader, StringComparison.OrdinalIgnoreCase));
+                       string.Equals(h.Key, ContentTypeHeader, StringComparison.OrdinalIgnoreCase));
             return header.Value ?? defaultValue;
         }
 


### PR DESCRIPTION
We just had a failure because the pact specified a content-type header in a request, and com-pact tried to add that header to the HttpRequestMessage object.

.NET does not allow that header on the HttpRequestMessage, but instead it should be added to the HttpContent.

This PR excludes that specific header when adding headers from the pact to the HttpRequestMessage, and instead uses the specified value to replace the content type within the HttpContent object.

There are likely other headers with restrictions (I didn't know about this one until we hit this problem), so a better pattern may be required long term, but this fixes the immediate issue we have in our project using Com-Pact.